### PR TITLE
test: update e2e to match new routes

### DIFF
--- a/ui/src/lib/features/k8s/configs/uds-exemptions/store.ts
+++ b/ui/src/lib/features/k8s/configs/uds-exemptions/store.ts
@@ -9,7 +9,12 @@ import type {
 } from 'uds-core-types/src/pepr/operator/crd/generated/exemption-v1alpha1'
 
 import { ResourceStore } from '$features/k8s/store'
-import { type ColumnWrapper, type CommonRow, type ResourceStoreInterface, type ResourceWithTable } from '$features/k8s/types'
+import {
+  type ColumnWrapper,
+  type CommonRow,
+  type ResourceStoreInterface,
+  type ResourceWithTable,
+} from '$features/k8s/types'
 import ExemptionDetails from './exemption-details/component.svelte'
 import ExemptionMatcher from './exemption-matcher/component.svelte'
 import ExemptionPolicies from './exemption-policies/component.svelte'

--- a/ui/src/lib/features/k8s/index.ts
+++ b/ui/src/lib/features/k8s/index.ts
@@ -14,4 +14,3 @@ export { default as StatefulsetTable } from './workloads/statefulsets/component.
 
 export { default as UDSExemptionTable } from './configs/uds-exemptions/component.svelte'
 export { default as UDSPackageTable } from './configs/uds-packages/component.svelte'
-

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -86,7 +86,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Config' }).click()
       await page.getByRole('link', { name: 'UDS Packages' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-config')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-configs')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-uds-packages')).toBeVisible()
     })
 
@@ -94,7 +94,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Config' }).click()
       await page.getByRole('link', { name: 'UDS Exemptions' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-config')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-configs')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-uds-exemptions')).toBeVisible()
     })
 
@@ -102,7 +102,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Config' }).click()
       await page.getByRole('link', { name: 'ConfigMaps' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-config')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-configs')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-configmaps')).toBeVisible()
     })
 
@@ -110,7 +110,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Config' }).click()
       await page.getByRole('link', { name: 'Secrets' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-config')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-configs')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-secrets')).toBeVisible()
     })
   })
@@ -186,7 +186,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Network' }).click()
       await page.getByRole('link', { name: /^Services$/ }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-network')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-networks')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-services')).toBeVisible()
     })
 
@@ -194,7 +194,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Network' }).click()
       await page.getByRole('link', { name: 'Virtual Services' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-network')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-networks')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-virtual-services')).toBeVisible()
     })
 
@@ -202,7 +202,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Network' }).click()
       await page.getByRole('link', { name: 'Network Policies' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-network')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-networks')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-network-policies')).toBeVisible()
     })
 
@@ -210,7 +210,7 @@ test.describe('Navigation', async () => {
       await page.getByRole('button', { name: 'Network' }).click()
       await page.getByRole('link', { name: 'Endpoints' }).click()
 
-      await expect(page.getByTestId('breadcrumb-item-network')).toBeVisible()
+      await expect(page.getByTestId('breadcrumb-item-networks')).toBeVisible()
       await expect(page.getByTestId('breadcrumb-item-endpoints')).toBeVisible()
     })
   })


### PR DESCRIPTION
## Description
Fixing an issue where the end to end navigation tests broke due to a renaming of the route key name/ title

## Related Issue

- #29 
