### PR TITLE
fix: empty endpoints are shown as Pending

### DIFF
--- a/ui/src/lib/components/Link/component.svelte
+++ b/ui/src/lib/components/Link/component.svelte
@@ -7,12 +7,16 @@
   export let text: string
 </script>
 
-<a
-  {href}
-  {target}
-  on:click|stopPropagation
-  rel="noopener noreferrer"
-  class="font-medium text-blue-600 dark:text-blue-500 hover:underline pr-4"
->
-  {text}
-</a>
+{#if href !== ''}
+  <a
+    {href}
+    {target}
+    on:click|stopPropagation
+    rel="noopener noreferrer"
+    class="font-medium text-blue-600 dark:text-blue-500 hover:underline pr-4"
+  >
+    {text}
+  </a>
+{:else}
+  <span class="dark:text-gray-400 mt-4 text-sm">{text}</span>
+{/if}

--- a/ui/src/lib/components/Link/component.svelte
+++ b/ui/src/lib/components/Link/component.svelte
@@ -7,7 +7,7 @@
   export let text: string
 </script>
 
-{#if href !== ''}
+{#if href}
   <a
     {href}
     {target}

--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -250,9 +250,9 @@
                         {/each}
                       </ul>
                     {:else if modifier === 'link-external'}
-                      <Link href={value.href || ''} text={value.text || value} target={'_blank'} />
+                      <Link href={value.href || ''} text={value.text || ''} target={'_blank'} />
                     {:else if modifier === 'link-internal'}
-                      <Link href={value.href || ''} text={value.text || value} target={''} />
+                      <Link href={value.href || ''} text={value.text || ''} target={''} />
                     {:else if key === 'namespace'}
                       <button
                         on:click|stopPropagation={() => namespace.set(value)}

--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -250,9 +250,9 @@
                         {/each}
                       </ul>
                     {:else if modifier === 'link-external'}
-                      <Link href={value.href || value} text={value.text || value} target={'_blank'} />
+                      <Link href={value.href || ''} text={value.text || value} target={'_blank'} />
                     {:else if modifier === 'link-internal'}
-                      <Link href={value.href || value} text={value.text || value} target={''} />
+                      <Link href={value.href || ''} text={value.text || value} target={''} />
                     {:else if key === 'namespace'}
                       <button
                         on:click|stopPropagation={() => namespace.set(value)}

--- a/ui/src/lib/features/k8s/applications/endpoints/component.test.ts
+++ b/ui/src/lib/features/k8s/applications/endpoints/component.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present The UDS Authors
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, vi } from 'vitest'
 
 import type { ZarfPackage } from '$features/k8s/applications/packages/types'

--- a/ui/src/lib/features/k8s/applications/endpoints/component.test.ts
+++ b/ui/src/lib/features/k8s/applications/endpoints/component.test.ts
@@ -3,7 +3,14 @@
 
 import { beforeEach, vi } from 'vitest'
 
-import { testK8sTableWithCustomColumns, testK8sTableWithDefaults } from '$features/k8s/test-helper'
+import type { ZarfPackage } from '$features/k8s/applications/packages/types'
+import {
+  expectEqualIgnoringFields,
+  MockResourceStore,
+  testK8sTableWithCustomColumns,
+  testK8sTableWithDefaults,
+} from '$features/k8s/test-helper'
+import type { ResourceWithTable } from '$features/k8s/types'
 import Component from './component.svelte'
 import { createStore } from './store'
 
@@ -29,4 +36,60 @@ suite('StatefulsetTable Component', () => {
     description,
     disableRowClick: true,
   })
+
+  vi.mock('../../store.ts', async (importOriginal) => {
+    const mockData = [
+      {
+        apiVersion: 'uds.dev/v1alpha1',
+        kind: 'Package',
+        metadata: {
+          creationTimestamp: '2021-09-29T20:00:00Z',
+          name: 'foo',
+          namespace: 'foo',
+        },
+        spec: {
+          network: {
+            expose: [
+              {
+                service: 'foo',
+                selector: {
+                  ' "app.kubernetes.io/name"': 'foo',
+                },
+                gateway: 'tenant',
+                host: 'foo',
+                port: 9898,
+              },
+            ],
+          },
+        },
+        status: {
+          phase: 'Pending',
+        },
+      },
+    ] as unknown as ZarfPackage[]
+
+    const original: Record<string, unknown> = await importOriginal()
+    return {
+      ...original,
+      ResourceStore: vi.fn().mockImplementation((url, transform) => new MockResourceStore(url, transform, mockData)),
+    }
+  })
+
+  const expectedTables = [
+    {
+      name: 'foo',
+      url: {
+        href: '',
+        sort: '',
+        text: 'Pending',
+      },
+      namespace: 'foo',
+      status: 'Pending',
+    },
+  ]
+
+  const store = createStore()
+  const start = store.start as unknown as () => ResourceWithTable<ZarfPackage, any>[]
+  expect(store.url).toEqual('/api/v1/resources/configs/uds-packages?dense=true')
+  expectEqualIgnoringFields(start()[0].table, expectedTables[0] as unknown, ['creationTimestamp'])
 })

--- a/ui/src/lib/features/k8s/applications/endpoints/store.ts
+++ b/ui/src/lib/features/k8s/applications/endpoints/store.ts
@@ -26,6 +26,9 @@ export function createStore(): ResourceStoreInterface<Resource, Row> {
   const url = `/api/v1/resources/configs/uds-packages?dense=true`
 
   const endpointBuilder = (r: Resource, e: Expose) => {
+    if (r.status?.phase === 'Pending') {
+      return { href: '', sort: '', text: 'Pending' }
+    }
     const url = r.status?.endpoints?.find((ep) => ep.includes(`${e.host}.`)) ?? ''
     return {
       href: `https://${url}`,

--- a/ui/src/lib/features/k8s/configs/uds-packages/links/component.svelte
+++ b/ui/src/lib/features/k8s/configs/uds-packages/links/component.svelte
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2024-Present The UDS Authors -->
+
 <script lang="ts">
   import { Link } from '$components'
 

--- a/ui/src/lib/features/k8s/test-helper.ts
+++ b/ui/src/lib/features/k8s/test-helper.ts
@@ -18,7 +18,7 @@ export function testK8sTableWithDefaults(Component: ComponentType, props: Record
 
     render(Component)
 
-    // Ensure name and ooltip desc aren't empty
+    // Ensure name and tooltip desc aren't empty
     const name: string = props.name as string
     expect(name).toBeTruthy()
     const description: string = props.description as string


### PR DESCRIPTION
## Description

Previously, endpoints in Pending state were shown as "[Object object]", this updates them to show as "Pending"

![Screenshot 2024-08-06 at 3 30 13 PM](https://github.com/user-attachments/assets/1e6d52aa-917e-4787-8e72-ce6249fbdeb9)

