### PR TITLE
fix: pod status color

### DIFF
--- a/ui/src/lib/features/k8s/workloads/pods/component.test.ts
+++ b/ui/src/lib/features/k8s/workloads/pods/component.test.ts
@@ -171,7 +171,7 @@ suite('PodTable Component', () => {
     },
     restarts: 1,
     controlled_by: 'DaemonSet',
-    status: 'Running',
+    status: { component: SvelteComponent, props: { status: 'Running' } },
     node: '',
   }
 
@@ -187,6 +187,7 @@ suite('PodTable Component', () => {
     'creationTimestamp',
     'containers.component',
     'metrics.component',
+    'status.component',
   ])
   vi.unstubAllGlobals()
 })

--- a/ui/src/lib/features/k8s/workloads/pods/status/component.svelte
+++ b/ui/src/lib/features/k8s/workloads/pods/status/component.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let status: string
+
+  const statusClasses = {
+    Running: 'text-green-400',
+    Stopped: 'text-red-400',
+    Pending: 'text-orange-300',
+  }
+
+  $: statusClass = statusClasses[status as keyof typeof statusClasses]
+</script>
+
+{#if status}
+  <span class={statusClass}>
+    {status}
+  </span>
+{:else}
+  -
+{/if}

--- a/ui/src/lib/features/k8s/workloads/pods/status/component.test.ts
+++ b/ui/src/lib/features/k8s/workloads/pods/status/component.test.ts
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/svelte'
+import Status from './component.svelte'
+
+describe('Status component', () => {
+  test('renders text-green-400 for Running', () => {
+    const { container } = render(Status, { props: { status: 'Running' } })
+    expect(container.firstChild).toHaveClass('text-green-400')
+  })
+  test('renders text-red-400 for Running', () => {
+    const { container } = render(Status, { props: { status: 'Stopped' } })
+    expect(container.firstChild).toHaveClass('text-red-400')
+  })
+  test('renders text-yellow-500 for Running', () => {
+    const { container } = render(Status, { props: { status: 'Pending' } })
+    expect(container.firstChild).toHaveClass('text-orange-300')
+  })
+})

--- a/ui/src/lib/features/k8s/workloads/pods/store.ts
+++ b/ui/src/lib/features/k8s/workloads/pods/store.ts
@@ -9,6 +9,7 @@ import { type ColumnWrapper, type CommonRow, type ResourceStoreInterface } from 
 import ContainerStatus from './containers/component.svelte'
 import PodMetrics from './metrics/component.svelte'
 import { parseCPU } from './metrics/utils'
+import Status from './status/component.svelte'
 
 interface Row extends CommonRow {
   containers: {
@@ -21,7 +22,7 @@ interface Row extends CommonRow {
   restarts: number
   controlled_by: string
   node: string
-  status: string
+  status: { component: typeof Status; props: { status: string } }
   metrics: {
     component: typeof PodMetrics
     sort: number
@@ -81,7 +82,7 @@ export function createStore(): ResourceStoreInterface<Resource, Row> {
     },
     restarts: r.status?.containerStatuses?.reduce((acc, curr) => acc + curr.restartCount, 0) ?? 0,
     controlled_by: r.metadata?.ownerReferences?.at(0)?.kind ?? '',
-    status: r.status?.phase ?? '',
+    status: { component: Status, props: { status: r.status?.phase ?? '' } },
     // @todo: This will not work due to using the default sparerResource stream
     node: r.spec?.nodeName ?? '',
   }))


### PR DESCRIPTION
## Description
add color to status

based colors on https://www.figma.com/design/zmKcJ9Xin7ChzyGy6RCFLe/UDS-Runtime-(UI%2FCLI)?node-id=3723-2949&t=SFK3K04QAwtQF1VD-0

## Related Issue

Resolves #169

## Additional Context
I explored adding the style to the column (e.g. ['status, '<style>']) but as it works atm, that will only handle 1 status case. so went for a component that handles the style logic based on status instead.

![Screenshot from 2024-08-07 20-49-42](https://github.com/user-attachments/assets/d6df0e48-e3e9-47f1-aae0-c506b38c62db)

