### PR TITLE
feat: adding e2e tests for DataTable

### DIFF
--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -139,13 +139,13 @@
   <div class="table-container">
     <div class="table-content">
       <div class="table-header">
-        <span class="dark:text-white" data-testid={`${name}-table-header`}>{name}</span>
+        <span class="dark:text-white" data-testid="table-header">{name}</span>
         {#if isFiltering}
-          <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>
+          <span class="dark:text-gray-500 pl-2" data-testid="table-header-results">
             (showing {$rows.length} of {$numResources})
           </span>
         {:else}
-          <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>({$numResources})</span>
+          <span class="dark:text-gray-500 pl-2" data-testid="table-header-results">({$numResources})</span>
         {/if}
         <div class="relative group">
           <Information class="ml-2 w-4 h-4 text-gray-400" />
@@ -201,11 +201,11 @@
         <div class="flex-grow"></div>
         <div>
           {#if isNamespaced}
-            <select id="stream" bind:value={$namespace} data-testid={`${name}-table-filter-namespace-select`}>
-              <option value="" data-testid={`${name}-namespace-select-all`}>All Namespaces</option>
+            <select id="stream" bind:value={$namespace} data-testid="table-filter-namespace-select">
+              <option value="" data-testid="namespace-select-all">All Namespaces</option>
               <hr />
               {#each $namespaces as ns}
-                <option value={ns.table.name} data-testid={`${name}-namespace-select-${ns.table.name}`}>
+                <option value={ns.table.name} data-testid={`namespace-select-${ns.table.name}`}>
                   {ns.table.name}
                 </option>
               {/each}

--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -139,11 +139,13 @@
   <div class="table-container">
     <div class="table-content">
       <div class="table-header">
-        <span class="dark:text-white">{name}</span>
+        <span class="dark:text-white" data-testid={`${name}-table-header`}>{name}</span>
         {#if isFiltering}
-          <span class="dark:text-gray-500 pl-2">(showing {$rows.length} of {$numResources})</span>
+          <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>
+            (showing {$rows.length} of {$numResources})
+          </span>
         {:else}
-          <span class="dark:text-gray-500 pl-2">({$numResources})</span>
+          <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>({$numResources})</span>
         {/if}
         <div class="relative group">
           <Information class="ml-2 w-4 h-4 text-gray-400" />
@@ -199,11 +201,13 @@
         <div class="flex-grow"></div>
         <div>
           {#if isNamespaced}
-            <select id="stream" bind:value={$namespace}>
-              <option value="">All Namespaces</option>
+            <select id="stream" bind:value={$namespace} data-testid={`${name}-namespace-select`}>
+              <option value="" data-testid={`${name}-namespace-select-all`}>All Namespaces</option>
               <hr />
               {#each $namespaces as ns}
-                <option value={ns.table.name}>{ns.table.name}</option>
+                <option value={ns.table.name} data-testid={`${name}-namespace-select-${ns.table.name}`}>
+                  {ns.table.name}
+                </option>
               {/each}
             </select>
           {/if}

--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -201,7 +201,7 @@
         <div class="flex-grow"></div>
         <div>
           {#if isNamespaced}
-            <select id="stream" bind:value={$namespace} data-testid={`${name}-namespace-select`}>
+            <select id="stream" bind:value={$namespace} data-testid={`${name}-table-filter-namespace-select`}>
               <option value="" data-testid={`${name}-namespace-select-all`}>All Namespaces</option>
               <hr />
               {#each $namespaces as ns}

--- a/ui/src/lib/features/k8s/cluster-overview/component.svelte
+++ b/ui/src/lib/features/k8s/cluster-overview/component.svelte
@@ -206,7 +206,7 @@
     <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
       <div class="px-4 py-5 sm:p-6">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">Running Nodes</dt>
-        <dd class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white">
+        <dd class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white" data-testid="node-count">
           {clusterData.totalNodes}
         </dd>
       </div>

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -14,9 +14,8 @@ test.describe('Navigation', async () => {
   test('Overview page', async ({ page }) => {
     await page.getByRole('link', { name: 'Overview' }).click()
 
-    const query = '1' // number of running nodes
-    const element = page.locator(`//dd[normalize-space(text())="${query}"]`)
-    await expect(element).toHaveText('1') // ensure exact match
+    const nodeCountEl = page.getByTestId(`node-count`)
+    await expect(nodeCountEl).toHaveText('1')
   })
 
   test.describe('navigates to Applications', async () => {

--- a/ui/tests/sse.spec.ts
+++ b/ui/tests/sse.spec.ts
@@ -4,6 +4,9 @@
 import k8s from '@kubernetes/client-node'
 import { expect, test } from '@playwright/test'
 
+// Annotate entire file as serial.
+test.describe.configure({ mode: 'serial' })
+
 async function deletePod(namespace: string, podName: string) {
   try {
     const kc = new k8s.KubeConfig()

--- a/ui/tests/sse.spec.ts
+++ b/ui/tests/sse.spec.ts
@@ -13,7 +13,7 @@ async function deletePod(namespace: string, podName: string) {
     kc.loadFromDefault() // Load the kubeconfig file from default location
 
     const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
-    await k8sApi.deleteNamespacedPod({ name: podName, namespace: namespace })
+    await k8sApi.deleteNamespacedPod({ name: podName, namespace: namespace, gracePeriodSeconds: 0 })
     console.log(`Pod ${podName} deleted successfully`)
   } catch (err) {
     console.error(`Failed to delete pod ${podName}:`, err)

--- a/ui/tests/table.spec.ts
+++ b/ui/tests/table.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024-Present The UDS Authors
+
+import { expect, test } from '@playwright/test'
+
+test.describe('DataTable', async () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/workloads/pods')
+  })
+
+  test('filters rows when we click the namespace link in a row', async ({ page }) => {
+    await page.getByRole('button', { name: 'podinfo' }).click()
+
+    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
+
+    await page.locator('#stream').selectOption({ label: 'All Namespaces' })
+
+    await page.getByRole('button', { name: 'kube-system' }).first().click()
+
+    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 3 of 7)')
+  })
+
+  test('filters rows when we select the namespace from the drop down option', async ({ page }) => {
+    await page.locator('#stream').selectOption({ label: 'podinfo' })
+
+    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
+
+    await page.locator('#stream').selectOption({ label: 'kube-system' })
+
+    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 3 of 7)')
+  })
+})

--- a/ui/tests/table.spec.ts
+++ b/ui/tests/table.spec.ts
@@ -11,22 +11,22 @@ test.describe('DataTable', async () => {
   test('filters rows when we click the namespace link in a row', async ({ page }) => {
     await page.getByRole('button', { name: 'podinfo' }).click()
 
-    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
+    expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 1 of 7)')
 
-    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'All Namespaces' })
+    await page.getByTestId('table-filter-namespace-select').selectOption({ label: 'All Namespaces' })
 
     await page.getByRole('button', { name: 'kube-system' }).first().click()
 
-    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 3 of 7)')
+    expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 3 of 7)')
   })
 
   test('filters rows when we select the namespace from the drop down option', async ({ page }) => {
-    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'podinfo' })
+    await page.getByTestId('table-filter-namespace-select').selectOption({ label: 'podinfo' })
 
-    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
+    expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 1 of 7)')
 
-    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'kube-system' })
+    await page.getByTestId('table-filter-namespace-select').selectOption({ label: 'kube-system' })
 
-    expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 3 of 7)')
+    expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 3 of 7)')
   })
 })

--- a/ui/tests/table.spec.ts
+++ b/ui/tests/table.spec.ts
@@ -13,7 +13,7 @@ test.describe('DataTable', async () => {
 
     expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
 
-    await page.locator('#stream').selectOption({ label: 'All Namespaces' })
+    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'All Namespaces' })
 
     await page.getByRole('button', { name: 'kube-system' }).first().click()
 
@@ -21,11 +21,11 @@ test.describe('DataTable', async () => {
   })
 
   test('filters rows when we select the namespace from the drop down option', async ({ page }) => {
-    await page.locator('#stream').selectOption({ label: 'podinfo' })
+    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'podinfo' })
 
     expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 1 of 7)')
 
-    await page.locator('#stream').selectOption({ label: 'kube-system' })
+    await page.getByTestId('Pods-table-filter-namespace-select').selectOption({ label: 'kube-system' })
 
     expect(await page.getByTestId('Pods-table-header-results').textContent()).toBe('(showing 3 of 7)')
   })


### PR DESCRIPTION
## Description
Testing the namespace functionality. This can be achieved by clicking on a row which has a namespace action or by selection a namespace from the drop down on the table header

## Related Issue

- #180 

## Screenshots

Here are some screenshots of what the ID's generate to with the code used to generate them. In this case the resource name is being used i.e. Pod to generate ID's specific to this resource on the DataTable. Every table will have unique ID's based on the resource for these 2 items (i.e. header results and drop down option)

```Svelte
<div class="table-header">
  <span class="dark:text-white" data-testid={`${name}-table-header`}>{name}</span>
  {#if isFiltering}
    <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>
      (showing {$rows.length} of {$numResources})
    </span>
  {:else}
    <span class="dark:text-gray-500 pl-2" data-testid={`${name}-table-header-results`}>({$numResources})</span>
  {/if}
  <div class="relative group">
    <Information class="ml-2 w-4 h-4 text-gray-400" />
    <div class="tooltip tooltip-right min-w-72">
      <div class="whitespace-normal">{description}</div>
    </div>
  </div>
</div>
```
<img width="687" alt="Screenshot 2024-08-08 at 12 49 08 PM" src="https://github.com/user-attachments/assets/51fb8d71-32be-4691-9e50-690f1f3040e2">

```Svelte
<select id="stream" bind:value={$namespace} data-testid={`${name}-namespace-select`}>
  <option value="" data-testid={`${name}-namespace-select-all`}>All Namespaces</option>
  <hr />
  {#each $namespaces as ns}
    <option value={ns.table.name} data-testid={`${name}-namespace-select-${ns.table.name}`}>
      {ns.table.name}
    </option>
  {/each}
</select>
```

<img width="984" alt="Screenshot 2024-08-08 at 12 48 47 PM" src="https://github.com/user-attachments/assets/b557dd4f-3f28-4557-bb54-aa45f2112386">
