### PR TITLE
fix(ui): deployments table not showing accurate available count

### DIFF
--- a/ui/src/lib/features/k8s/workloads/deployments/component.test.ts
+++ b/ui/src/lib/features/k8s/workloads/deployments/component.test.ts
@@ -37,7 +37,13 @@ suite('DeploymentTable Component', () => {
     const mockData = [
       {
         metadata: { name: 'test', namespace: 'default', creationTimestamp: '2024-09-29T20:00:00Z' },
-        status: { readyReplicas: 1, replicas: 2, updatedReplicas: 1, conditions: [{ type: 'Available' }] },
+        status: {
+          availableReplicas: 2,
+          readyReplicas: 1,
+          replicas: 2,
+          updatedReplicas: 1,
+          conditions: [{ type: 'Available' }],
+        },
       },
     ] as unknown as V1Deployment[]
 
@@ -54,7 +60,7 @@ suite('DeploymentTable Component', () => {
       namespace: 'default',
       ready: '1 / 2',
       up_to_date: 1,
-      available: 1,
+      available: 2,
     },
   ]
 

--- a/ui/src/lib/features/k8s/workloads/deployments/store.ts
+++ b/ui/src/lib/features/k8s/workloads/deployments/store.ts
@@ -20,7 +20,7 @@ export function createStore(): ResourceStoreInterface<Resource, Row> {
   const transform = transformResource<Resource, Row>((r) => ({
     ready: `${r.status?.readyReplicas ?? 0} / ${r.status?.replicas ?? 0}`,
     up_to_date: r.status?.updatedReplicas ?? 0,
-    available: r.status?.conditions?.filter((c) => c.type === 'Available').length ?? 0,
+    available: r.status?.availableReplicas ?? 0,
   }))
 
   const store = new ResourceStore<Resource, Row>(url, transform, 'name')


### PR DESCRIPTION
## Description
Workloads > Deployments > Available column was showing a single available replica even if there were more than 1 because it was looking at the number of `type: 'Available'` conditions in `.status.conditions`. This changes the logic to read the `availableReplicas` field instead.

## Related Issue

Resolves #173 

![Screenshot from 2024-08-09 08-32-03](https://github.com/user-attachments/assets/5e994334-c539-4c93-993f-7ac3ece0bc82)

![Screenshot from 2024-08-09 08-42-11](https://github.com/user-attachments/assets/602c7e2a-eea1-450b-b1e0-b3d53a81670f)

