### PR TITLE
chore: make uds package host configurable for nightly

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -9,7 +9,7 @@ spec:
       - service: uds-runtime
         selector:
           app: uds-runtime
-        host: runtime
+        host: {{ .Values.package.host}}
         gateway: {{ .Values.package.gateway }}
         port: 8080
         targetPort: 8080

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,3 +7,4 @@ image:
   pullPolicy: Always
 package:
   gateway: admin
+  host: runtime

--- a/hack/nightly/nightly-values.yaml
+++ b/hack/nightly/nightly-values.yaml
@@ -2,3 +2,4 @@ image:
   tag: nightly-unstable
 package:
   gateway: tenant
+  host: runtime-canary


### PR DESCRIPTION
## Description
Configure package host so nightly can be set to `runtime-canary` for ephemeral cluster.
