### PR TITLE
chore: add inputs to actions setup

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,15 +1,44 @@
 name: Setup Environment
 description: Environment Setup
 
+inputs:
+  go:
+    description: 'Go version'
+    required: false
+    default: "true"
+  node:
+    description: 'Node.js version'
+    required: false
+    default: "true"
+  swagger:
+    description: 'Swagger CLI'
+    required: false
+    default: "true"
+  k3d:
+    description: 'k3d'
+    required: false
+    default: "true"
+  qemu:
+    description: 'QEMU'
+    required: false
+    default: "false"
+  buildx:
+    description: 'Docker Buildx'
+    required: false
+    default: "false"
+
+
 runs:
   using: composite
   steps:
     - name: Install Go
+      if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
         go-version: 1.21.x
 
     - name: Setup Node.js
+      if: ${{ inputs.node == 'true' }}
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
         node-version: 21.1.0
@@ -24,16 +53,20 @@ runs:
         brew install uds@0.14.0
 
     - name: Install Swagger CLI
+      if: ${{ inputs.swagger == 'true' }}
       shell: bash
       run: |
         go install github.com/swaggo/swag/cmd/swag@latest
 
     - name: Set up QEMU
+      if: ${{ inputs.qemu == 'true' }}
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
     - name: Set up Docker Buildx
+      if: ${{ inputs.buildx == 'true' }}
       uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
     - name: Install k3d
+      if: ${{ inputs.k3d == 'true' }}
       shell: bash
       run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.3 bash

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Setup Environment (Go, Node, Homebrew, UDS CLI, k3d)
         uses: ./.github/actions/setup
+        with:
+          qemu: "true"
+          buildx: "true"
 
       - name: Publish
         run: |

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Setup Environment (Go, Node, Homebrew, UDS CLI, k3d)
         uses: ./.github/actions/setup
+        with:
+          qemu: "true"
+          buildx: "true"
 
       - name: Login to GHCR
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0


### PR DESCRIPTION
## Description
add inputs to actions setup so that we can customize for each workflow which tools we want to install. this should speed up CI a little bit in some places.
