### PR TITLE
feat(api): strip annotations from sparse resources

### DIFF
--- a/pkg/api/resources/list.go
+++ b/pkg/api/resources/list.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
@@ -121,6 +122,9 @@ func (r *ResourceList) notifyChange(obj interface{}, eventType string) {
 		return
 	}
 
+	// Always remove managedFields from the resource
+	delete(resource.Object["metadata"].(map[string]interface{}), "managedFields")
+
 	// Extract the sparse object
 	sparseResource := r.extractSparseObject(resource)
 
@@ -160,19 +164,19 @@ func (r *ResourceList) extractSparseObject(obj *unstructured.Unstructured) *unst
 		Object: map[string]interface{}{},
 	}
 
-	// Safely extract apiVersion
+	// Safely extract apiVersion (GetAPIVersion() may not work)
 	if apiVersion, exists := obj.Object["apiVersion"]; exists {
 		sparseObj.Object["apiVersion"] = apiVersion
 	}
 
-	// Safely extract kind
+	// Safely extract kind (GetKind() may not work)
 	if kind, exists := obj.Object["kind"]; exists {
 		sparseObj.Object["kind"] = kind
 	}
 
-	// Extract metadata
-	if metadata, exists := obj.Object["metadata"]; exists {
-		sparseObj.Object["metadata"] = metadata
+	// Extract metadata and deep copy it to avoid mutating the original object
+	if metadata, ok := obj.Object["metadata"].(map[string]interface{}); ok {
+		sparseObj.Object["metadata"] = runtime.DeepCopyJSON(metadata)
 	}
 
 	// Extract type if it exists
@@ -196,8 +200,8 @@ func (r *ResourceList) extractSparseObject(obj *unstructured.Unstructured) *unst
 		sparseObj.Object["status"] = nil
 	}
 
-	// Strip the metadata managed fields
-	delete(sparseObj.Object["metadata"].(map[string]interface{}), "managedFields")
+	// Strip the metadata annotations from the copy
+	delete(sparseObj.Object["metadata"].(map[string]interface{}), "annotations")
 
 	return sparseObj
 }


### PR DESCRIPTION
## Description

This PR strips annotations from sparse datasets to avoid excess data and prevent leaky secret data with the `kubectl.kubernetes.io/last-applied-configuration` [annotation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/). It also corrects the mutation of the original object by `extractSparseObject` by making a deep copy of the object metadata prior to modifying it. Removal of `managedFields` was moved to the source function to affect all resource views. 
