### PR TITLE
chore: undo release-as 0.3.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "bump-minor-pre-major": true,
       "draft": false,
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.3.0",
       "changelog-sections": [
         { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug Fixes", "hidden": false },


### PR DESCRIPTION
## Description

in order to get the release to work we had to add release-as 0.3.0 to the release please config, shouldn't need this in the future.