### PR TITLE
feat(ui): add functionality to Pepr table

### DIFF
--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -2,7 +2,7 @@
 <!-- SPDX-FileCopyrightText: 2024-Present The UDS Authors -->
 
 <script lang="ts">
-  import { ChevronUp, Export, Information, Search } from 'carbon-icons-svelte'
+  import { ChevronDown, ChevronUp, Export, Filter, Information, Search } from 'carbon-icons-svelte'
   import { onDestroy } from 'svelte'
   import { writable, type Unsubscriber } from 'svelte/store'
 
@@ -17,6 +17,16 @@
   let streamFilter = ''
   let eventSource: EventSource | null = null
   let unsubscribePage: Unsubscriber
+
+  const streamOptions = [
+    { value: '', label: 'All Data' },
+    { value: 'policies', label: 'All UDS Policies' },
+    { value: 'allowed', label: 'UDS Policies: Allowed' },
+    { value: 'denied', label: 'UDS Policies: Denied' },
+    { value: 'mutated', label: 'UDS Policies: Mutated' },
+    { value: 'operator', label: 'UDS Operator' },
+    { value: 'failed', label: 'Errors and Denials' },
+  ]
 
   const peprStream = writable<PeprEvent[]>([])
   export let columns = ['event', 'resource', 'details', 'count', 'timestamp']
@@ -170,7 +180,9 @@
         <div class="relative group">
           <Information class="ml-2 w-4 h-4 text-gray-400" />
           <div class="tooltip tooltip-right min-w-72">
-            <div class="whitespace-normal">{'Hello description'}</div>
+            <div class="whitespace-normal">
+              {'These are UDS Operator logs scraped from Pepr running in the cluster'}
+            </div>
           </div>
         </div>
       </div>
@@ -189,22 +201,62 @@
             bind:value={$search}
           />
         </div>
-
         <div class="grid w-full grid-cols-1 md:grid-cols-4 md:gap-4 lg:w-2/3">
-          <div class="w-full">
-            <select id="stream" bind:value={streamFilter} on:change={handleStreamChange}>
-              <option value="">All Data</option>
-              <hr />
-              <option value="policies">UDS Policies</option>
-              <option value="allowed">UDS Policies: Allowed</option>
-              <option value="denied">UDS Policies: Denied</option>
-              <option value="mutated">UDS Policies: Mutated</option>
-              <hr />
-              <option value="operator">UDS Operator</option>
-              <option value="failed">Errors and Denials</option>
-            </select>
+          <div class="flex items-center w-full">
+            <button
+              id="filterDropdownButton"
+              data-dropdown-toggle="filterDropdown"
+              class="hover:text-primary-700 flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200 md:w-auto dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
+              type="button"
+              data-testid="datatable-filter-dropdown"
+            >
+              <Filter class="mr-2 h-4 w-4 text-gray-400" />
+              {streamFilter ? streamOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
+              <ChevronDown class="ml-2 h-4 w-4 text-gray-400" />
+            </button>
+            <div id="filterDropdown" class="z-10 hidden w-48 rounded-lg bg-white p-3 shadow dark:bg-gray-700">
+              <h6 class="mb-3 text-sm font-medium text-gray-900 dark:text-white">Filter By</h6>
+              <ul class="space-y-2 text-sm" aria-labelledby="filterDropdownButton">
+                {#each streamOptions as option}
+                  <li class="flex items-center">
+                    <input
+                      id={option.value || 'all'}
+                      type="radio"
+                      name="streamFilter"
+                      value={option.value}
+                      class="h-4 w-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600"
+                      bind:group={streamFilter}
+                      on:change={handleStreamChange}
+                    />
+                    <label
+                      for={option.value || 'all'}
+                      class="ms-2 block text-sm font-medium text-gray-900 dark:text-gray-300"
+                    >
+                      {option.label}
+                    </label>
+                  </li>
+                {/each}
+              </ul>
+            </div>
           </div>
         </div>
+
+        <!--        <div class="grid w-full grid-cols-1 md:grid-cols-4 md:gap-4 lg:w-2/3">-->
+        <!--          <div class="flex items-center w-full">-->
+        <!--            <Filter class="mr-2 h-4 w-4 text-gray-400" />-->
+        <!--            <select id="stream" bind:value={streamFilter} on:change={handleStreamChange}>-->
+        <!--              <option value="">All Data</option>-->
+        <!--              <hr />-->
+        <!--              <option value="policies">UDS Policies</option>-->
+        <!--              <option value="allowed">Allowed</option>-->
+        <!--              <option value="denied">Denied</option>-->
+        <!--              <option value="mutated">Mutated</option>-->
+        <!--              <hr />-->
+        <!--              <option value="operator">UDS Operator</option>-->
+        <!--              <option value="failed">Errors and Denials</option>-->
+        <!--            </select>-->
+        <!--          </div>-->
+        <!--        </div>-->
         <div
           class="flex flex-shrink-0 flex-col space-y-3 md:flex-row md:items-center md:space-x-3 md:space-y-0 lg:justify-end"
         >

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -205,45 +205,42 @@
             bind:value={$search}
           />
         </div>
-        <div class="grid w-full grid-cols-1 md:grid-cols-4 md:gap-4 lg:w-2/3">
-          <div class="flex items-center w-full">
-            <button
-              id="filterDropdownButton"
-              data-dropdown-toggle="filterDropdown"
-              class="hover:text-primary-700 flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200 md:w-auto dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
-              type="button"
-              data-testid="datatable-filter-dropdown"
-            >
-              <Filter class="mr-2 h-4 w-4 text-gray-400" />
-              {streamFilter ? streamSelectOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
-              <ChevronDown class="ml-2 h-4 w-4 text-gray-400" />
-            </button>
-            <div id="filterDropdown" class="z-10 hidden w-48 rounded-lg bg-white p-3 shadow dark:bg-gray-700">
-              <h6 class="mb-3 text-sm font-medium text-gray-900 dark:text-white">Filter By</h6>
-              <ul class="space-y-2 text-sm" aria-labelledby="filterDropdownButton">
-                {#each streamSelectOptions as option}
-                  <li class="flex items-center">
-                    <input
-                      id={option.value || 'all'}
-                      type="radio"
-                      name="streamFilter"
-                      value={option.value}
-                      class="h-4 w-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600"
-                      bind:group={streamFilter}
-                      on:change={handleStreamChange}
-                    />
-                    <label
-                      for={option.value || 'all'}
-                      class="ms-2 block text-sm font-medium text-gray-900 dark:text-gray-300"
-                    >
-                      {option.label}
-                    </label>
-                  </li>
-                {/each}
-              </ul>
-            </div>
-          </div>
+        <button
+          id="filterDropdownButton"
+          data-dropdown-toggle="filterDropdown"
+          class="hover:text-primary-700 flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200 md:w-auto dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
+          type="button"
+          data-testid="datatable-filter-dropdown"
+        >
+          <Filter class="mr-2 h-4 w-4 text-gray-400" />
+          {streamFilter ? streamSelectOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
+          <ChevronDown class="ml-2 h-4 w-4 text-gray-400" />
+        </button>
+        <div id="filterDropdown" class="z-10 hidden w-48 rounded-lg bg-white p-3 shadow dark:bg-gray-700">
+          <h6 class="mb-3 text-sm font-medium text-gray-900 dark:text-white">Filter By</h6>
+          <ul class="space-y-2 text-sm" aria-labelledby="filterDropdownButton">
+            {#each streamSelectOptions as option}
+              <li class="flex items-center">
+                <input
+                  id={option.value || 'all'}
+                  type="radio"
+                  name="streamFilter"
+                  value={option.value}
+                  class="h-4 w-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600"
+                  bind:group={streamFilter}
+                  on:change={handleStreamChange}
+                />
+                <label
+                  for={option.value || 'all'}
+                  class="ms-2 block text-sm font-medium text-gray-900 dark:text-gray-300"
+                >
+                  {option.label}
+                </label>
+              </li>
+            {/each}
+          </ul>
         </div>
+        <div class="flex-grow"></div>
         <div
           class="flex flex-shrink-0 flex-col space-y-3 md:flex-row md:items-center md:space-x-3 md:space-y-0 lg:justify-end"
         >

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -2,7 +2,7 @@
 <!-- SPDX-FileCopyrightText: 2024-Present The UDS Authors -->
 
 <script lang="ts">
-  import { ChevronDown, ChevronUp, Export, Filter, Information, Search } from 'carbon-icons-svelte'
+  import { ChevronUp, Export, Information, Search } from 'carbon-icons-svelte'
   import { onDestroy } from 'svelte'
   import { writable, type Unsubscriber, derived } from 'svelte/store'
 

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -240,23 +240,6 @@
             </div>
           </div>
         </div>
-
-        <!--        <div class="grid w-full grid-cols-1 md:grid-cols-4 md:gap-4 lg:w-2/3">-->
-        <!--          <div class="flex items-center w-full">-->
-        <!--            <Filter class="mr-2 h-4 w-4 text-gray-400" />-->
-        <!--            <select id="stream" bind:value={streamFilter} on:change={handleStreamChange}>-->
-        <!--              <option value="">All Data</option>-->
-        <!--              <hr />-->
-        <!--              <option value="policies">UDS Policies</option>-->
-        <!--              <option value="allowed">Allowed</option>-->
-        <!--              <option value="denied">Denied</option>-->
-        <!--              <option value="mutated">Mutated</option>-->
-        <!--              <hr />-->
-        <!--              <option value="operator">UDS Operator</option>-->
-        <!--              <option value="failed">Errors and Denials</option>-->
-        <!--            </select>-->
-        <!--          </div>-->
-        <!--        </div>-->
         <div
           class="flex flex-shrink-0 flex-col space-y-3 md:flex-row md:items-center md:space-x-3 md:space-y-0 lg:justify-end"
         >

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -18,8 +18,8 @@
   let eventSource: EventSource | null = null
   let unsubscribePage: Unsubscriber
 
-  const streamOptions = [
-    { value: '', label: 'All Data' },
+  const streamSelectOptions = [
+    { value: '', label: 'All Pepr Events' },
     { value: 'policies', label: 'All UDS Policies' },
     { value: 'allowed', label: 'UDS Policies: Allowed' },
     { value: 'denied', label: 'UDS Policies: Denied' },
@@ -211,13 +211,13 @@
               data-testid="datatable-filter-dropdown"
             >
               <Filter class="mr-2 h-4 w-4 text-gray-400" />
-              {streamFilter ? streamOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
+              {streamFilter ? streamSelectOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
               <ChevronDown class="ml-2 h-4 w-4 text-gray-400" />
             </button>
             <div id="filterDropdown" class="z-10 hidden w-48 rounded-lg bg-white p-3 shadow dark:bg-gray-700">
               <h6 class="mb-3 text-sm font-medium text-gray-900 dark:text-white">Filter By</h6>
               <ul class="space-y-2 text-sm" aria-labelledby="filterDropdownButton">
-                {#each streamOptions as option}
+                {#each streamSelectOptions as option}
                   <li class="flex items-center">
                     <input
                       id={option.value || 'all'}

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -205,40 +205,19 @@
             bind:value={$search}
           />
         </div>
-        <button
-          id="filterDropdownButton"
-          data-dropdown-toggle="filterDropdown"
-          class="hover:text-primary-700 flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200 md:w-auto dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white dark:focus:ring-gray-700"
-          type="button"
-          data-testid="datatable-filter-dropdown"
-        >
-          <Filter class="mr-2 h-4 w-4 text-gray-400" />
-          {streamFilter ? streamSelectOptions.find((option) => option.value === streamFilter)?.label : 'All Data'}
-          <ChevronDown class="ml-2 h-4 w-4 text-gray-400" />
-        </button>
-        <div id="filterDropdown" class="z-10 hidden w-48 rounded-lg bg-white p-3 shadow dark:bg-gray-700">
-          <h6 class="mb-3 text-sm font-medium text-gray-900 dark:text-white">Filter By</h6>
-          <ul class="space-y-2 text-sm" aria-labelledby="filterDropdownButton">
-            {#each streamSelectOptions as option}
-              <li class="flex items-center">
-                <input
-                  id={option.value || 'all'}
-                  type="radio"
-                  name="streamFilter"
-                  value={option.value}
-                  class="h-4 w-4 border-gray-300 focus:ring-2 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600"
-                  bind:group={streamFilter}
-                  on:change={handleStreamChange}
-                />
-                <label
-                  for={option.value || 'all'}
-                  class="ms-2 block text-sm font-medium text-gray-900 dark:text-gray-300"
-                >
-                  {option.label}
-                </label>
-              </li>
+        <div>
+          <select
+            id="stream"
+            bind:value={streamFilter}
+            on:change={handleStreamChange}
+            data-testid="table-filter-stream-select"
+          >
+            {#each streamSelectOptions as s}
+              <option value={s.value} data-testid={`stream-select-${s.label}`}>
+                {s.label}
+              </option>
             {/each}
-          </ul>
+          </select>
         </div>
         <div class="flex-grow"></div>
         <div

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -39,7 +39,7 @@
   // check for filtering
   let isFiltering = false
   $: {
-    isFiltering = !!$search || !!$sortBy
+    isFiltering = !!$search
   }
 
   function filterEvents(events: PeprEvent[], searchTerm: string): PeprEvent[] {

--- a/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/+page.svelte
@@ -29,7 +29,13 @@
   ]
 
   const peprStream = writable<PeprEvent[]>([])
-  export let columns = ['event', 'resource', 'details', 'count', 'timestamp']
+  export let columns = [
+    { name: 'event', style: 'w-2/12' },
+    { name: 'resource', style: 'w-3/12' },
+    { name: 'details', style: 'w-1/12' },
+    { name: 'count', style: 'w-1/12' },
+    { name: 'timestamp', style: 'w-5/12' },
+  ]
 
   // Initialize the stores
   let search = writable<string>('')
@@ -233,19 +239,19 @@
         <table>
           <thead>
             <tr>
-              {#each columns as header}
-                <th>
+              {#each columns as col}
+                <th class={col.style}>
                   <button
                     on:click={() => {
-                      $sortBy = header === 'resource' ? '_name' : header
+                      $sortBy = col.name === 'resource' ? '_name' : col.name
                       $sortAsc = !$sortAsc
                     }}
                   >
-                    {header.replaceAll('_', ' ')}
+                    {col.name.replaceAll('_', ' ')}
                     <ChevronUp
                       class="sort
                       {$sortAsc ? 'rotate-180' : ''}
-                      {$sortBy === header ? 'opacity-100' : 'opacity-0'}"
+                      {$sortBy === col.name ? 'opacity-100' : 'opacity-0'}"
                     />
                   </button>
                 </th>
@@ -282,19 +288,19 @@
             <tbody class="animate-pulse">
               {#each skeletonRows as w}
                 <tr class="border-b border-gray-700">
-                  <td class="w-2/12">
+                  <td class={columns[0].style}>
                     <div class="h-6 rounded bg-gray-600 w-20"></div>
                   </td>
-                  <td class="w-3/12">
+                  <td class={columns[1].style}>
                     <div class="h-6 bg-gray-500 rounded {w}"></div>
                   </td>
-                  <td class="w-1/12">
+                  <td class={columns[2].style}>
                     <div class="h-6 bg-gray-600 rounded w-20"></div>
                   </td>
-                  <td class="w-1/12">
+                  <td class={columns[3].style}>
                     <div class="h-6 bg-gray-600 rounded w-8"></div>
                   </td>
-                  <td class="w-5/12">
+                  <td class={columns[4].style}>
                     <div class="h-6 bg-gray-600 rounded w-1/2"></div>
                   </td>
                 </tr>

--- a/ui/tests/monitor.spec.ts
+++ b/ui/tests/monitor.spec.ts
@@ -24,8 +24,8 @@ test.describe('Monitor', async () => {
 
   test('searching while using filter dropdown', async ({ page }) => {
     await page.getByTestId('datatable-search').fill('podinfo/podinfo')
-    await page.getByTestId('datatable-filter-dropdown').click()
-    await page.getByText('UDS Policies: Allowed').click()
+    await page.getByTestId('table-filter-stream-select').click()
+    await page.selectOption('select#stream', 'UDS Policies: Allowed')
 
     // wait for data to load
     await page.waitForSelector('.pepr-event.ALLOWED')

--- a/ui/tests/monitor.spec.ts
+++ b/ui/tests/monitor.spec.ts
@@ -7,7 +7,60 @@ import * as fs from 'node:fs'
 test.describe('Monitor', async () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/monitor/pepr')
+
+    // wait for data to load
+    await page.waitForSelector('.pepr-event.ALLOWED')
   })
+
+  test('searching with "All Pepr Events selected', async ({ page }) => {
+    await page.getByTestId('datatable-search').fill('podinfo/podinfo')
+
+    const results = await page.getByTestId('table-header-results').textContent()
+    expect(results).toBeTruthy()
+
+    const numbers = results!.match(/\d+/g)!.map(Number)
+    expect(numbers![0]).toBeLessThan(numbers![1])
+  })
+
+  test('searching while using filter dropdown', async ({ page }) => {
+    await page.getByTestId('datatable-search').fill('podinfo/podinfo')
+    await page.getByTestId('datatable-filter-dropdown').click()
+    await page.getByText('UDS Policies: Allowed').click()
+
+    // wait for data to load
+    await page.waitForSelector('.pepr-event.ALLOWED')
+
+    const results = await page.getByTestId('table-header-results').textContent()
+    expect(results).toBeTruthy()
+
+    const numbers = results!.match(/\d+/g)!.map(Number)
+    expect(numbers![0]).toBeLessThan(numbers![1])
+  })
+
+  test('sorting by count', async ({ page }) => {
+    // get first row
+    let rows = await page.$$('table tr:first-child')
+    let firstRow = await rows[1].textContent() // index 0 is the table header
+    expect(firstRow).toBeTruthy()
+    let match = firstRow!.match(/\s(\d+)\s/)
+    expect(match).toBeTruthy()
+    const originalCount = parseInt(match![1])
+
+    // click "count" to sort
+    await page.getByText('count').click()
+
+    // get first row after sorting
+    rows = await page.$$('table tr:first-child')
+    firstRow = await rows[1].textContent() // index 0 is the table header
+    expect(firstRow).toBeTruthy()
+    match = firstRow!.match(/\s(\d+)\s/)
+    expect(match).toBeTruthy()
+    const newCount = parseInt(match![1])
+
+    // sorted 'count' value should be greater than the original
+    expect(newCount).toBeGreaterThan(originalCount)
+  })
+
   test('Exports logs', async ({ page }) => {
     // wait for pepr data to load
     await page.waitForSelector('.pepr-event.ALLOWED')

--- a/ui/tests/table.spec.ts
+++ b/ui/tests/table.spec.ts
@@ -40,7 +40,7 @@ test.describe('DataTable', async () => {
     expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 1 of 8)')
   })
 
-  test('filters rows when enterting search values with "Metadata" selected', async ({ page }) => {
+  test('filters rows when entering search values with "Metadata" selected', async ({ page }) => {
     await page.getByTestId('datatable-filter-dropdown').click()
     await page.getByLabel('Metadata').click()
 
@@ -49,7 +49,7 @@ test.describe('DataTable', async () => {
     expect(await page.getByTestId('table-header-results').textContent()).toBe('(showing 4 of 8)')
   })
 
-  test('filters rows when enterting search values with "Name" selected', async ({ page }) => {
+  test('filters rows when entering search values with "Name" selected', async ({ page }) => {
     await page.getByTestId('datatable-filter-dropdown').click()
     await page.getByLabel('Name').click()
 


### PR DESCRIPTION
## Description

- Adds searching + sorting to Pepr table
- Aligns Pepr table with the rest of the app

Noting that I intentionally duplicated code from our `Datatable` component. That component is already pretty complex and I felt that making it generic enough to handle the Pepr data would add even more complexity

Updated Pepr table:
![Screenshot 2024-09-10 at 12 18 38 PM](https://github.com/user-attachments/assets/97b6710b-273f-41ea-8173-77c323b1a48d)



## Related Issue

- #296 
