### PR TITLE
feat(ui): adjusting drawer margins

### DIFF
--- a/ui/src/lib/components/k8s/Drawer/component.svelte
+++ b/ui/src/lib/components/k8s/Drawer/component.svelte
@@ -119,7 +119,7 @@
 
     <!-- Content -->
 
-    <div class="flex-grow overflow-y-auto dark:text-gray-300">
+    <div class="flex-grow overflow-y-auto dark:text-gray-300 pb-20">
       {#if activeTab === 'metadata'}
         <!-- Metadata tab -->
         <div class="bg-gray-800 text-gray-200 p-6 rounded-lg">
@@ -160,7 +160,7 @@
         </div>
       {:else if activeTab === 'yaml'}
         <!-- YAML tab -->
-        <div class="text-gray-200 p-4 pb-20">
+        <div class="text-gray-200 p-4">
           <code class="text-sm text-gray-500 dark:text-gray-400 whitespace-pre w-full block">
             <!-- We turned off svelte/no-at-html-tags eslint rule because we are using DOMPurify to sanitize -->
             {@html DOMPurify.sanitize(hljs.highlight(YAML.stringify(resource), { language: 'yaml' }).value)}


### PR DESCRIPTION
## Description
The drawer tab has an issue when the content is taller than the height of the container where it cuts off the bottom of the content

This PR addresses that issue

## Related Issue
- #292 

## Screenshots
<img width="1595" alt="Screenshot 2024-09-10 at 10 41 23 AM" src="https://github.com/user-attachments/assets/61b8beff-cdfd-4dc6-bf48-4a28e7ae3e4d">
