### PR TITLE
feat(ui): reload data view when cluster reconnection is successful

### DIFF
--- a/ui/src/lib/utils/cluster-check/cluster-check.ts
+++ b/ui/src/lib/utils/cluster-check/cluster-check.ts
@@ -12,7 +12,7 @@ export function checkClusterConnection() {
     addToast({
       type: 'error',
       message: disconnectedMsg,
-      timeoutSecs: 500,
+      timeoutSecs: 1000,
     })
   }
 
@@ -29,6 +29,13 @@ export function checkClusterConnection() {
         message: 'Cluster connection restored',
         timeoutSecs: 10,
       })
+
+      // Dispatch custom event for reconnection
+      // use window instead of svelte createEventDispatcher to trigger event globally
+      const event = new CustomEvent('cluster-reconnected', {
+        detail: { message: 'Cluster connection restored' },
+      })
+      window.dispatchEvent(event)
     }
 
     // only show error toast once and make timeout really long
@@ -36,7 +43,7 @@ export function checkClusterConnection() {
       addToast({
         type: 'error',
         message: disconnectedMsg,
-        timeoutSecs: 500,
+        timeoutSecs: 1000,
       })
     }
   }


### PR DESCRIPTION
## Description
Uses a custom event, dispatched from the cluster health check utility to the Datatable, for "cycling" the current store on cluster reconnection. 

**NOTE**: in a spike PR (#317), we tested using svelte's createEventDispatcher with a window event listener on the Datatable, which did not work. We then tried placing `on:cluster-reconnected={handler}` on calls to Datatable but that wouldn't work either because of the need to extract the handler out of Datatable, which needs access to the current stop() set by rows.start() inside Datatable.

## Testing

* create cluster
* run backend
* run frontend
* re-create cluster of the same name
* watch pods in UI -- you should see an error toast and eventually a successfully reconnected toast and a small flash on the table and then any new updates happening to pods.

## Related Issue

resolves #300 
