### PR TITLE
fix(api): errors from trying to get kubecontext while in cluster

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -878,7 +878,7 @@ func checkHealth(k8sResources *K8sResources, disconnected chan error) http.Handl
 
 		// Function to check the cluster health when running out of cluster
 		checkCluster := func() {
-			versionInfo, err := k8sResources.Client.Clientset.ServerVersion()
+			versionInfo, err := k8sResources.client.Clientset.ServerVersion()
 			response := map[string]string{}
 
 			// if err then connection is lost
@@ -912,8 +912,10 @@ func checkHealth(k8sResources *K8sResources, disconnected chan error) http.Handl
 			}
 		}
 
+		// DON'T return error to user in case sensitive
+		inCluster, _ := isRunningInCluster()
 		// If running in cluster don't check for version and send error or reconnected events
-		if isRunningInCluster() {
+		if inCluster {
 			checkCluster = func() {
 				response := map[string]string{
 					"success": "in-cluster",

--- a/pkg/api/start_test.go
+++ b/pkg/api/start_test.go
@@ -25,15 +25,15 @@ func TestHandleReconnection(t *testing.T) {
 	}
 
 	k8sResources := &K8sResources{
-		Client:          &k8s.Clients{},
-		Cache:           &resources.Cache{},
-		Cancel:          func() {},
-		OriginalCtx:     "original-context",
-		OriginalCluster: "original-cluster",
+		client:         &k8s.Clients{},
+		cache:          &resources.Cache{},
+		cancel:         func() {},
+		currentCtx:     "original-context",
+		currentCluster: "original-cluster",
 	}
 
-	require.Nil(t, k8sResources.Client.Clientset)
-	require.Nil(t, k8sResources.Cache.Pods)
+	require.Nil(t, k8sResources.client.Clientset)
+	require.Nil(t, k8sResources.cache.Pods)
 
 	createClientMock := func() (*k8s.Clients, error) {
 		return &k8s.Clients{Clientset: &kubernetes.Clientset{}}, nil
@@ -54,8 +54,8 @@ func TestHandleReconnection(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify that the K8sResources struct was updated
-	require.NotNil(t, k8sResources.Client.Clientset)
-	require.NotNil(t, k8sResources.Cache.Pods)
+	require.NotNil(t, k8sResources.client.Clientset)
+	require.NotNil(t, k8sResources.cache.Pods)
 
 	close(disconnected)
 }
@@ -66,11 +66,11 @@ func TestHandleReconnectionCreateClientError(t *testing.T) {
 	defer os.Unsetenv("RETRY_INTERVAL_MS")
 
 	k8sResources := &K8sResources{
-		Client:          &k8s.Clients{},
-		Cache:           &resources.Cache{},
-		Cancel:          func() {},
-		OriginalCtx:     "original-context",
-		OriginalCluster: "original-cluster",
+		client:         &k8s.Clients{},
+		cache:          &resources.Cache{},
+		cancel:         func() {},
+		currentCtx:     "original-context",
+		currentCluster: "original-cluster",
 	}
 
 	// Mock GetCurrentContext to return the same context and cluster as the original
@@ -96,8 +96,8 @@ func TestHandleReconnectionCreateClientError(t *testing.T) {
 	// Wait for the reconnection logic to attempt creating the client
 	time.Sleep(200 * time.Millisecond)
 
-	require.Nil(t, k8sResources.Client.Clientset)
-	require.Nil(t, k8sResources.Cache.Pods)
+	require.Nil(t, k8sResources.client.Clientset)
+	require.Nil(t, k8sResources.cache.Pods)
 
 	close(disconnected)
 }
@@ -108,11 +108,11 @@ func TestHandleReconnectionCreateCacheError(t *testing.T) {
 	defer os.Unsetenv("RETRY_INTERVAL_MS")
 
 	k8sResources := &K8sResources{
-		Client:          &k8s.Clients{},
-		Cache:           &resources.Cache{},
-		Cancel:          func() {},
-		OriginalCtx:     "original-context",
-		OriginalCluster: "original-cluster",
+		client:         &k8s.Clients{},
+		cache:          &resources.Cache{},
+		cancel:         func() {},
+		currentCtx:     "original-context",
+		currentCluster: "original-cluster",
 	}
 
 	// Mock GetCurrentContext to return the same context and cluster as the original
@@ -139,8 +139,8 @@ func TestHandleReconnectionCreateCacheError(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify that the K8sResources cache was not updated since cache creation failed
-	require.Nil(t, k8sResources.Client.Clientset)
-	require.Nil(t, k8sResources.Cache.Pods)
+	require.Nil(t, k8sResources.client.Clientset)
+	require.Nil(t, k8sResources.cache.Pods)
 
 	close(disconnected)
 }
@@ -155,11 +155,11 @@ func TestHandleReconnectionContextChanged(t *testing.T) {
 	}
 
 	k8sResources := &K8sResources{
-		Client:          &k8s.Clients{},
-		Cache:           &resources.Cache{},
-		Cancel:          func() {},
-		OriginalCtx:     "original-context",
-		OriginalCluster: "original-cluster",
+		client:         &k8s.Clients{},
+		cache:          &resources.Cache{},
+		cancel:         func() {},
+		currentCtx:     "original-context",
+		currentCluster: "original-cluster",
 	}
 
 	createClientMock := func() (*k8s.Clients, error) {
@@ -182,8 +182,8 @@ func TestHandleReconnectionContextChanged(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify that the K8sResources struct was not updated since the context/cluster has changed
-	require.Nil(t, k8sResources.Client.Clientset)
-	require.Nil(t, k8sResources.Cache.Pods)
+	require.Nil(t, k8sResources.client.Clientset)
+	require.Nil(t, k8sResources.cache.Pods)
 
 	close(disconnected)
 }


### PR DESCRIPTION
## Description
Fixes getCurrentContext() errors that occur when running the application in the cluster by not running reconnection handling in cluster and serving a different health check response to the UI.


## Testing
Tested manually and confirmed works. Will be submitting a follow up PR with a nightly smoke test to catch this kind of thing. It was a lot of code changes for this PR though.