### PR TITLE
fix: historical usage loading

### DIFF
--- a/ui/src/lib/features/k8s/cluster-overview/component.svelte
+++ b/ui/src/lib/features/k8s/cluster-overview/component.svelte
@@ -176,14 +176,14 @@
       series: [
         {
           name: 'CPU Usage',
-          data: clusterData.historicalUsage.map((point) => ({
+          data: (clusterData.historicalUsage ?? []).map((point) => ({
             x: new Date(point.Timestamp).getTime(),
             y: point.CPU / 1000, // Convert millicores to cores
           })),
         },
         {
           name: 'Memory Usage',
-          data: clusterData.historicalUsage.map((point) => ({
+          data: (clusterData.historicalUsage ?? []).map((point) => ({
             x: new Date(point.Timestamp).getTime(),
             y: point.Memory / (1024 * 1024 * 1024), // Convert bytes to GB
           })),


### PR DESCRIPTION
## Description
Fixes bug being seen specifically when looking at larger clusters where the app freezes/crashes if you try to load the cluster overview page  immediately after launching.