### PR TITLE
fix(api): flaky api tests

### DIFF
--- a/pkg/test/api_test.go
+++ b/pkg/test/api_test.go
@@ -311,7 +311,7 @@ func processResponseBody(body string) []byte {
 func testRoutesHelper(t *testing.T, tt TestRoute, uidMap map[string]string, r *chi.Mux) {
 	t.Run(tt.name, func(t *testing.T) {
 		// Create a new context with a timeout
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
## Description
Increases the context timeout for api route tests so that we increase the time for the go routine serving the SSE request to get data events back on networks with higher latency than local.

## Related Issue

Resolves #345 
