### PR TITLE
chore: api route test helper with retries and exponential backoff

### DIFF
--- a/pkg/test/api_test.go
+++ b/pkg/test/api_test.go
@@ -755,7 +755,6 @@ func testRoutesHelper(t *testing.T, tt TestRoute, uidMap map[string]string, r *c
 
 			// if data is not empty then perform assertions
 			if len(body) > 0 {
-				fmt.Println(rr.Body.String())
 				// If uidMap.expectedKind is empty (eg. {Pod: ""}), then we need to store a UID for this kind
 				if uidMap[tt.expectedKind] == "" {
 					keyIndx := 5


### PR DESCRIPTION
## Description
Introduces retries with backoff and increased context timeouts to the api route test helper to fix flaky tests in CI.

