### PR TITLE
fix: ensure pod counts are consistent

### DIFF
--- a/pkg/api/monitor/cluster.go
+++ b/pkg/api/monitor/cluster.go
@@ -43,7 +43,7 @@ func BindClusterOverviewHandler(cache *resources.Cache) func(w http.ResponseWrit
 			// Timestamp the data
 			clusterData.CurrentUsage.Timestamp = time.Now()
 			// Get all available pod metrics
-			clusterData.TotalPods = cache.PodMetrics.GetCount()
+			clusterData.TotalPods = len(cache.Pods.Resources)
 			// Get the current usage
 			clusterData.CurrentUsage.CPU, clusterData.CurrentUsage.Memory = cache.PodMetrics.GetUsage()
 			// Get the historical usage

--- a/pkg/api/monitor/cluster_test.go
+++ b/pkg/api/monitor/cluster_test.go
@@ -39,15 +39,32 @@ func TestBindClusterOverviewHandler(t *testing.T) {
 	podMetrics.Update("pod2", metrics["pod2"])
 
 	// Create ResourceList for nodes
-	resourceList := resources.ResourceList{
-		Resources:       make(map[string]*unstructured.Unstructured),
-		SparseResources: make(map[string]*unstructured.Unstructured),
+	nodeResourceList := resources.ResourceList{
+		Resources: make(map[string]*unstructured.Unstructured),
+	}
+
+	pods := map[string]*unstructured.Unstructured{
+		"pod1": {
+			Object: map[string]interface{}{
+				"name": "pod1",
+			},
+		},
+		"pod2": {
+			Object: map[string]interface{}{
+				"name": "pod2",
+			},
+		},
+	}
+
+	podResourceList := resources.ResourceList{
+		Resources: pods,
 	}
 
 	// Create a test cache
 	cache := &resources.Cache{}
 	cache.PodMetrics = podMetrics
-	cache.Nodes = &resourceList
+	cache.Pods = &podResourceList
+	cache.Nodes = &nodeResourceList
 
 	// Create a request to pass to our handler
 	req, err := http.NewRequest("GET", "/cluster-overview", nil)

--- a/ui/src/lib/features/k8s/cluster-overview/component.svelte
+++ b/ui/src/lib/features/k8s/cluster-overview/component.svelte
@@ -231,7 +231,7 @@
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
     <LinkCard path="/workloads/pods">
       <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">Running Pods</dt>
-      <dd class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white">
+      <dd class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white" data-testid="pod-count">
         {clusterData.totalPods}
       </dd>
     </LinkCard>

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -20,6 +20,23 @@ test.describe('Navigation', async () => {
     await expect(nodeCountEl).toHaveText('1')
   })
 
+  test('Ensure Overview page and pod page show same number of pods', async ({ page }) => {
+    // get pod count from overview page
+    await page.getByRole('link', { name: 'Overview' }).click()
+    const overviewPodCount = await page.getByTestId(`pod-count`).textContent()
+
+    // navigate to pods page and get pod count
+    await page.goto('/workloads/pods')
+    await page.waitForSelector('.emphasize:has-text("zarf")') // wait for pods to render
+    let podCount = await page.getByTestId('table-header-results').textContent()
+    expect(podCount).not.toBeNull()
+
+    // remove parentheses
+    podCount = podCount!.replace(/\(|\)/g, '')
+
+    await expect(overviewPodCount).toEqual(podCount)
+  })
+
   test.describe('navigates to Applications', async () => {
     test('Packages page', async ({ page }) => {
       await page.getByRole('button', { name: 'Applications' }).click()

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -27,7 +27,7 @@ test.describe('Navigation', async () => {
 
     // navigate to pods page and get pod count
     await page.goto('/workloads/pods')
-    await page.waitForSelector('.emphasize:has-text("zarf")') // wait for pods to render
+    await page.waitForSelector('.emphasize:has-text("podinfo")') // wait for pods to render
     let podCount = await page.getByTestId('table-header-results').textContent()
     expect(podCount).not.toBeNull()
 


### PR DESCRIPTION
## Description

ensures pod counts are consistent between Overview and Pods pages

## Related Issue

https://github.com/defenseunicorns/uds-runtime/issues/361
