### PR TITLE
feat(ui): truncating certain table cells

### DIFF
--- a/ui/src/lib/components/Tooltip/component.svelte
+++ b/ui/src/lib/components/Tooltip/component.svelte
@@ -20,16 +20,16 @@
     }
 
     isHovered = true
-    xOffset = event.pageX
-    yOffset = event.pageY
   }
+
   const mouseMove = (event: MouseEventType) => {
     // calculate if the columns is a certain percent off right side and render on the left side
     const diff = ((window.innerWidth - event.pageX) / window.innerWidth) * 100
 
-    const tooltipOffset = diff < 15 ? 500 : 200
+    const tooltipOffset = diff > 40 ? 200 : 500
+
     xOffset = event.pageX - tooltipOffset
-    yOffset = event.pageY - 110
+    yOffset = event.pageY - 75
   }
 
   const mouseLeave = () => (isHovered = false)

--- a/ui/src/lib/components/k8s/DataTable/component.svelte
+++ b/ui/src/lib/components/k8s/DataTable/component.svelte
@@ -296,7 +296,7 @@
                         </button>
                       {:else if style?.includes('truncate')}
                         <Tooltip title={value}>
-                          <div class={`w-full ${style}`}>
+                          <div class={`w-full ${style}`} style:width="100%">
                             {value}
                           </div>
                         </Tooltip>

--- a/ui/src/lib/features/k8s/configs/configmaps/component.svelte
+++ b/ui/src/lib/features/k8s/configs/configmaps/component.svelte
@@ -8,10 +8,10 @@
   import { createStore, type Columns } from './store'
 
   export let columns: Columns = [
-    ['name', 'emphasize'],
-    ['namespace'],
-    ['keys', 'line-clamp-3 max-w-screen-md'],
-    ['age'],
+    ['name', 'emphasize w-2/12 truncate'],
+    ['namespace', 'w-2/12'],
+    ['keys', 'w-7/12'],
+    ['age', 'w-1/12'],
   ]
   const name = 'ConfigMaps'
   const description = resourceDescriptions[name]

--- a/ui/src/lib/features/k8s/configs/secrets/component.svelte
+++ b/ui/src/lib/features/k8s/configs/secrets/component.svelte
@@ -8,11 +8,11 @@
   import { createStore, type Columns } from './store'
 
   export let columns: Columns = [
-    ['name', 'emphasize'],
-    ['namespace'],
-    ['type'],
-    ['keys', 'line-clamp-5 max-w-screen-md'],
-    ['age'],
+    ['name', 'emphasize w-3/12 truncate'],
+    ['namespace', 'w-2/12'],
+    ['type', 'w-2/12'],
+    ['keys', 'w-4/12 truncate'],
+    ['age', 'w-1/12'],
   ]
 
   const name = 'Secrets'


### PR DESCRIPTION
## Description
Add sizing to all tables that have cells that need to be truncated so that the other columns are properly sized



## Related Issue

- #301 

## Screenshots
<img width="1326" alt="Screenshot 2024-09-20 at 10 28 40 AM" src="https://github.com/user-attachments/assets/d114d8bf-3650-42df-b3e5-05601a1540b0">
<img width="1332" alt="Screenshot 2024-09-20 at 10 28 51 AM" src="https://github.com/user-attachments/assets/1da34927-cc7a-4bea-a28d-6592ce68684a">
<img width="1329" alt="Screenshot 2024-09-20 at 10 29 32 AM" src="https://github.com/user-attachments/assets/5c6ad153-080a-4ec9-a99f-6df823a9ff19">
