### PR TITLE
feat: make deployment resources configurable and up default memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/uds/uds-runtime:<
 
 \*_See [all tags](https://github.com/defenseunicorns/uds-runtime/pkgs/container/packages%2Fuds%2Fuds-runtime)_
 
+#### Resource Requirements
+
+When running in cluster, the Runtime pod will need more or less resources based on the number of resources in the cluster it will be watching. The [current defaults](./chart/values.yaml) work for a cluster running mainly UDS Core (about 44 pods). For running in larger clusters, UDS Core + SWF + Leapfrog for example (150+ pods), the `resource.limits.memory` will need to be more like `2Gi`.
+
 ### Locally (Out of Cluster)
 
 1. clone this repo

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,11 +22,11 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "250m"
+              memory: {{ .Values.resources.requests.memory | quote }}
+              cpu: {{ .Values.resources.requests.cpu | quote }}
             limits:
-              memory: "512Mi"
-              cpu: "750m"
+              memory: {{ .Values.resources.limits.memory | quote }}
+              cpu: {{ .Values.resources.limits.cpu | quote }}
           env:
             - name: AUTH_SVC_ENABLED
               value: {{ .Values.sso.enabled | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,3 +11,12 @@ package:
   gateway: admin
   host: runtime
   domain: "###ZARF_VAR_DOMAIN###"
+
+# Default requests and limits when running only uds-core (increase for production)
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "750m"


### PR DESCRIPTION
## Description
Makes the resource limits and requests configurable so users can adjust per environment needs. This also update the default resource limit to 1Gi.

## Related Issue

resolves #368 
