### PR TITLE
fix: fixing memory bar for overview page

### DIFF
--- a/ui/src/lib/components/ProgressBar/component.svelte
+++ b/ui/src/lib/components/ProgressBar/component.svelte
@@ -32,7 +32,7 @@
 <div class="flex flex-col">
   <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700 mt-3">
     <div
-      class={`dark:bg-${unit === 'GB' ? 'green' : 'blue'}-600 rounded-full ${sizeMapping[size]}`}
+      class={`${unit === 'GB' ? 'bg-green-500' : 'dark:bg-blue-600'} rounded-full ${sizeMapping[size]}`}
       style={`width: ${calculatedWidth}%`}
     ></div>
   </div>


### PR DESCRIPTION
## Description
Fixing issue with memory bar still not showing color

This was because the css that is generated did not include the class we were using. Autoprefxr must have missed the class somehow

## Related Issue

- #380 
