### PR TITLE
fix: fixing issue with firefox not supporting text-wrap: pretty

### DIFF
--- a/ui/src/routes/monitor/pepr/[[stream]]/(details)/mutated-details/MutatedDetails.svelte
+++ b/ui/src/routes/monitor/pepr/[[stream]]/(details)/mutated-details/MutatedDetails.svelte
@@ -16,7 +16,7 @@
       {/if}
       <h3 class="font-bold">{key}:</h3>
       {#each ops as op}
-        <p class="text-pretty tooltip-w">
+        <p class="text-balance tooltip-w">
           {op.path}
           {#if op.value}
             <span class="text-blue-400">={JSON.stringify(op.value)}</span>


### PR DESCRIPTION
## Description
Fixing issue with text going outside of the tooltip due to Firefox not supporting `text-wrap: pretty`

## Related
<img width="1586" alt="Screenshot 2024-09-23 at 1 40 27 PM" src="https://github.com/user-attachments/assets/9c83e2b3-eb6d-48d9-88f6-05ad5e34503e">
 Issue

- #293 

### Screenshots
#### Before
<img width="1588" alt="Screenshot 2024-09-23 at 1 39 33 PM" src="https://github.com/user-attachments/assets/63ececb3-e912-47fe-90b5-8f083e7304db">



#### After
<img width="1286" alt="Screenshot 2024-09-23 at 1 38 50 PM" src="https://github.com/user-attachments/assets/e11d7ac6-a6cf-46b8-8f64-5ccd01df719a">
