### PR TITLE
feat(api): adds jwt group validation when in-cluster

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -29,4 +29,5 @@ spec:
       groups:
         anyOf:
           - /UDS Core/Admin
+          - /UDS Core/Auditor
   {{- end }}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	k8s.io/metrics v0.31.1
 )
 
+require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+
 require (
 	atomicgo.dev/cursor v0.2.0 // indirect
 	atomicgo.dev/keyboard v0.2.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.5
 require (
 	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/go-chi/chi/v5 v5.1.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.16.3
@@ -14,8 +15,6 @@ require (
 	k8s.io/client-go v0.31.1
 	k8s.io/metrics v0.31.1
 )
-
-require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 
 require (
 	atomicgo.dev/cursor v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 h1:0VpGH+cDhbDtdcweoyCVsF3fhN8kejK6rFe/2FFX2nU=

--- a/pkg/api/auth/session.go
+++ b/pkg/api/auth/session.go
@@ -109,6 +109,7 @@ var allowedGroups = []string{
 	"/UDS Core/Auditor",
 }
 
+// RequireJWT is a middleware that checks if the request has a valid JWT token with the required groups.
 func RequireJWT(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")

--- a/pkg/api/auth/session_test.go
+++ b/pkg/api/auth/session_test.go
@@ -79,6 +79,11 @@ func TestRequireJWT(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 		},
 		{
+			name:           "Valid token with empty group",
+			token:          createToken([]string{}),
+			expectedStatus: http.StatusForbidden,
+		},
+		{
 			name:           "Invalid token",
 			token:          "invalid.token.string",
 			expectedStatus: http.StatusUnauthorized,

--- a/pkg/api/auth/session_test.go
+++ b/pkg/api/auth/session_test.go
@@ -4,8 +4,11 @@
 package auth
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +42,70 @@ func TestRemoveSession(t *testing.T) {
 
 	require.Empty(t, storage.sessionID, "expected sessionID to be empty after removal")
 	require.False(t, storage.ValidateSession(sessionID), "expected sessionID to be invalid after removal")
+}
+
+func TestRequireJWT(t *testing.T) {
+	// Create a sample handler that the middleware will wrap
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create the middleware
+	middleware := RequireJWT(nextHandler)
+
+	// Helper function to create a JWT token without signing
+	createToken := func(groups []string) string {
+		claims := jwt.MapClaims{
+			"groups": groups,
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+		tokenString, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		return tokenString
+	}
+
+	tests := []struct {
+		name           string
+		token          string
+		expectedStatus int
+	}{
+		{
+			name:           "Valid token with allowed group",
+			token:          createToken([]string{"/UDS Core/Admin"}),
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Valid token without allowed group",
+			token:          createToken([]string{"guest"}),
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "Invalid token",
+			token:          "invalid.token.string",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "Missing token",
+			token:          "",
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a request to pass to our handler
+			req, _ := http.NewRequest("GET", "/", nil)
+			if tt.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.token)
+			}
+
+			// Create a ResponseRecorder to record the response
+			rr := httptest.NewRecorder()
+
+			// Call the middleware
+			middleware.ServeHTTP(rr, req)
+
+			// Check the status code
+			require.Equal(t, tt.expectedStatus, rr.Code, "handler returned wrong status code")
+		})
+	}
 }

--- a/pkg/test/api_test.go
+++ b/pkg/test/api_test.go
@@ -340,55 +340,6 @@ func TestClusterHealth(t *testing.T) {
 	})
 }
 
-func TestAuthSVCToken(t *testing.T) {
-	// must set before setup() is called
-	os.Setenv("AUTH_SVC_ENABLED", "true")
-	defer os.Unsetenv("AUTH_SVC_ENABLED")
-
-	r, err := setup()
-	require.NoError(t, err)
-
-	defer teardown()
-
-	t.Run("authorized with token", func(t *testing.T) {
-		// Create a new context with a timeout
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/api/v1/resources/workloads/pods", nil)
-		req.Header.Set("Authorization", "Bearer valid-token")
-
-		// Start serving the request for 1 second
-		go func(ctx context.Context) {
-			r.ServeHTTP(rr, req)
-		}(ctx)
-
-		// wait for the context to be done
-		<-ctx.Done()
-		require.Equal(t, http.StatusOK, rr.Code)
-		require.NotEmpty(t, rr.Body.String())
-	})
-
-	t.Run("no token", func(t *testing.T) {
-		// Create a new context with a timeout
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/api/v1/resources/workloads/pods", nil)
-
-		// Start serving the request for 1 second
-		go func(ctx context.Context) {
-			r.ServeHTTP(rr, req)
-		}(ctx)
-
-		// wait for the context to be done
-		<-ctx.Done()
-		require.Equal(t, http.StatusUnauthorized, rr.Code)
-	})
-}
-
 func TestTopLevelResourceRoutes(t *testing.T) {
 	r, err := setup()
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

- Performs group validation from the JWT received from Keycloak/Authservice.
- Removes deprecated api auth tests
- In addition to the unit tests, testing was performed by building a local Runtime image + Zarf pkg and deploying into a UDS Core dev cluster, then logging in via Google SSO to verify access


