### PR TITLE
chore: update slim core with authsvc deployment and bump k3d version

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -35,4 +35,4 @@ runs:
 
     - name: Install k3d
       shell: bash
-      run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.3 bash
+      run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.7.4 bash

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -8,11 +8,11 @@ tasks:
       - task: commmon:k3d-full-cluster
 
   - name: slim-cluster
-    description: "Create a k3d cluster and deploy core slim dev with metrics server"
+    description: "Create a k3d cluster and deploy core slim dev with authsvc"
     actions:
       - task: common:k3d-test-cluster
       - task: clone-core
-      - task: metrics-server
+      - task: authsvc
 
   - name: simple-cluster
     description: "Create a uds-k3d cluster, no core"
@@ -42,3 +42,9 @@ tasks:
     actions:
       - cmd: uds zarf package create .github/uds-core/src/metrics-server --confirm --flavor upstream -o build/
       - cmd: uds zarf package deploy build/zarf-package-uds-core-metrics-server*.tar.zst --components=metrics-server --confirm
+
+  - name: authsvc
+    description: "Create and deploy authsvc from cloned core"
+    actions:
+      - cmd: uds zarf package create .github/uds-core/src/authservice --confirm --flavor upstream -o build/
+      - cmd: uds zarf package deploy build/zarf-package-uds-core-authservice*.tar.zst --confirm

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -31,11 +31,10 @@ tasks:
       - cmd: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
 
   - name: clone-core
-    description: "Clone uds-core for custom slim dev setup"
+    description: "Clone uds-core into tmp dir for custom slim dev setup"
     actions:
       - cmd: rm -fr tmp && git clone --depth=1 https://github.com/defenseunicorns/uds-core.git tmp/uds-core
         description: clone UDS Core
-        dir: tmp
 
   - name: metrics-server
     description: "Create and deploy metrics server from cloned core"

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -33,18 +33,18 @@ tasks:
   - name: clone-core
     description: "Clone uds-core for custom slim dev setup"
     actions:
-      - cmd: rm -r uds-core || true
-      - cmd: git clone https://github.com/defenseunicorns/uds-core.git
-        dir: .github/
+      - cmd: rm -fr tmp && git clone --depth=1 https://github.com/defenseunicorns/uds-core.git tmp/uds-core
+        description: clone UDS Core
+        dir: tmp
 
   - name: metrics-server
     description: "Create and deploy metrics server from cloned core"
     actions:
-      - cmd: uds zarf package create .github/uds-core/src/metrics-server --confirm --flavor upstream -o build/
+      - cmd: uds zarf package create tmp/uds-core/src/metrics-server --confirm --flavor upstream -o build/
       - cmd: uds zarf package deploy build/zarf-package-uds-core-metrics-server*.tar.zst --components=metrics-server --confirm
 
   - name: authsvc
     description: "Create and deploy authsvc from cloned core"
     actions:
-      - cmd: uds zarf package create .github/uds-core/src/authservice --confirm --flavor upstream -o build/
+      - cmd: uds zarf package create tmp/uds-core/src/authservice --confirm --flavor upstream -o build/
       - cmd: uds zarf package deploy build/zarf-package-uds-core-authservice*.tar.zst --confirm

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -70,8 +70,7 @@ tasks:
     description: install min resources for UDS Core
     actions:
       # todo: refactor this with UDS functional layers: https://github.com/defenseunicorns/uds-runtime/issues/172
-      - cmd: rm -fr tmp && git clone --depth=1 https://github.com/defenseunicorns/uds-core.git tmp/uds-core
-        description: clone UDS Core
+      - task: setup:clone-core
       - cmd: npm ci && npx pepr deploy --confirm
         description: deploy UDS Core's Pepr module
         dir: tmp/uds-core


### PR DESCRIPTION
## Description
This adds authsvc to the slim-core deployment, which allows us to test authsvc protection for nightly and main releases while not bumping our runners to deploy full core. The latest versions of uds-k3d also require an updated version of k3d, so bumped to `5.7.4`.
