### PR TITLE
feat(ui): adding convention for figma to front end component naming

### DIFF
--- a/adr/0003-figma-to-code-naming-convention.md
+++ b/adr/0003-figma-to-code-naming-convention.md
@@ -1,0 +1,25 @@
+# 3 Figma to Code Naming Convention
+
+## Status
+
+proposed
+
+## Context
+
+In order to try to keep some sort of connection between the Figma designs and the components on the front end that are being built.
+
+## Decision
+
+A decision was made to name components based on the naming used by the flowbite Figma library, for components that we are using that are either blocks or what Figma calls "widges".
+
+### Examples...
+
+## Rationale
+
+### Creates a Convention
+
+In deciding to name components based on Figma (flowbite) designs, we are using a naming convention that everyone can follow.
+
+## Consequences
+
+If flowbite updates their component library in Figma and the names change, then there is going to be a disconnect between the library naming and the front end components.


### PR DESCRIPTION
## Description
This is an ADR to create a naming convention for the naming of components for the front end based on Figma designs

## Related Issue

- #395 

## Screenshots

### Examples
