### PR TITLE
chore(ui): re-enable svelte/no-at-html-tags rule

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -34,8 +34,6 @@ export default [
     ignores: ['build/', '.svelte-kit/', 'dist/'],
   },
   {
-    rules: {
-      'svelte/no-at-html-tags': 'off',
-    },
+    rules: {},
   },
 ]

--- a/ui/src/lib/components/k8s/Drawer/component.svelte
+++ b/ui/src/lib/components/k8s/Drawer/component.svelte
@@ -179,7 +179,8 @@
         <!-- YAML tab -->
         <div class="text-gray-200 p-4">
           <code class="text-sm text-gray-500 dark:text-gray-400 whitespace-pre w-full block">
-            <!-- We turned off svelte/no-at-html-tags eslint rule because we are using DOMPurify to sanitize -->
+            <!-- Disable svelte/no-at-html-tags eslint rule here because we are using DOMPurify to sanitize -->
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html DOMPurify.sanitize(hljs.highlight(YAML.stringify(resource), { language: 'yaml' }).value)}
           </code>
         </div>


### PR DESCRIPTION
## Description
Re-enables the eslint rule svelte/no-at-html-tags and ignores rule only for single instance where we're using DOMPurify.

## Related Issue

Resolves #437 
