### PR TITLE
feat(ui): update overview cards to navigate on click

### DIFF
--- a/ui/src/lib/components/ProgressBar/component.svelte
+++ b/ui/src/lib/components/ProgressBar/component.svelte
@@ -31,15 +31,17 @@
   }
 </script>
 
-<div class="bg-gray-200 rounded-full dark:bg-gray-700 mt-3">
-  <div
-    class={`${unit === 'GB' ? 'bg-green-500' : 'dark:bg-blue-600'} h-2.5 rounded-full ${sizeMapping[size]}`}
-    style={`width: ${calculatedWidth}%`}
-  />
-</div>
+<div class="flex flex-col">
+  <div class="bg-gray-200 rounded-full dark:bg-gray-700 mt-3">
+    <div
+      class={`${unit === 'GB' ? 'bg-green-500' : 'dark:bg-blue-600'} h-2.5 rounded-full ${sizeMapping[size]}`}
+      style={`width: ${calculatedWidth}%`}
+    />
+  </div>
 
-<div class="text-xs mt-1 font-normal text-gray-500 dark:text-gray-400 truncate overflow-ellipsis">
-  <span>
-    {progressText}
-  </span>
+  <div class="text-xs text-left mt-1 font-normal text-gray-500 dark:text-gray-400 truncate overflow-ellipsis">
+    <span>
+      {progressText}
+    </span>
+  </div>
 </div>

--- a/ui/src/lib/components/StatsWidget/ProgressBarWidget.svelte
+++ b/ui/src/lib/components/StatsWidget/ProgressBarWidget.svelte
@@ -16,7 +16,7 @@
 
 <Card>
   <div class="w-full">
-    <div class="w-full">
+    <div class="flex flex-col items-start">
       <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{statText}</dt>
       <dd class="mt-1 text-3xl font-semibold text-gray-900 dark:text-white">
         {value.toString()}%

--- a/ui/src/lib/components/StatsWidget/WithRightIconWidget.svelte
+++ b/ui/src/lib/components/StatsWidget/WithRightIconWidget.svelte
@@ -2,7 +2,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial -->
 
 <script lang="ts">
-  import { goto } from '$app/navigation'
   import { Card } from '$components'
   import { type CarbonIcon } from 'carbon-icons-svelte'
 
@@ -35,24 +34,22 @@
   $: iconThemeOption = themeMapping[iconTheme]
 </script>
 
-<Card>
-  <button on:click={() => goto(link)}>
-    <div class="flex items-center justify-start space-x-4">
-      <div class="{iconThemeOption['bgColor']} {iconThemeOption['bgColorDark']} p-3 rounded-md">
-        <svelte:component this={icon} size={24} color={iconThemeOption['iconColor']} />
-      </div>
-
-      <div class="flex flex-col items-start">
-        <dt
-          class="text-3xl font-semibold text-black dark:text-white truncate"
-          data-testid={`resource-count-${helperText.split(' ')[0].toLowerCase()}`}
-        >
-          {statText}
-        </dt>
-        <dd class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          {helperText}
-        </dd>
-      </div>
+<Card {link}>
+  <div class="flex items-center justify-start space-x-4">
+    <div class="{iconThemeOption['bgColor']} {iconThemeOption['bgColorDark']} p-3 rounded-md">
+      <svelte:component this={icon} size={24} color={iconThemeOption['iconColor']} />
     </div>
-  </button>
+
+    <div class="flex flex-col items-start">
+      <dt
+        class="text-3xl font-semibold text-black dark:text-white truncate"
+        data-testid={`resource-count-${helperText.split(' ')[0].toLowerCase()}`}
+      >
+        {statText}
+      </dt>
+      <dd class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {helperText}
+      </dd>
+    </div>
+  </div>
 </Card>

--- a/ui/src/lib/components/k8s/Card/component.svelte
+++ b/ui/src/lib/components/k8s/Card/component.svelte
@@ -2,14 +2,17 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial -->
 
 <script lang="ts">
+  import { goto } from '$app/navigation'
   import type { TailwindSizeType } from '$components/StatsWidget/types'
 
   export let size: TailwindSizeType = 32
+  export let link: string = ''
 </script>
 
-<div
+<button
+  on:click={() => goto(link)}
   data-testid="card-container"
   class={`bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg hover:dark:bg-gray-700 h-${size} px-5 sm:px-6 flex items-center`}
 >
   <slot />
-</div>
+</button>

--- a/ui/src/lib/components/k8s/Card/component.svelte
+++ b/ui/src/lib/components/k8s/Card/component.svelte
@@ -2,17 +2,16 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial -->
 
 <script lang="ts">
-  import { goto } from '$app/navigation'
   import type { TailwindSizeType } from '$components/StatsWidget/types'
 
   export let size: TailwindSizeType = 32
   export let link: string = ''
 </script>
 
-<button
-  on:click={() => goto(link)}
+<a
+  href={link}
   data-testid="card-container"
   class={`bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg hover:dark:bg-gray-700 h-${size} px-5 sm:px-6 flex items-center`}
 >
   <slot />
-</button>
+</a>

--- a/ui/tests/local-auth.spec.ts
+++ b/ui/tests/local-auth.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial('Authentication Tests', () => {
   test('data is visible on load, refresh, and new tab', async ({ page, context }) => {
     await page.goto(`/auth?token=${extractedToken}`)
     await page.getByRole('button', { name: 'Workloads' }).click()
-    await page.getByRole('link', { name: 'Pods' }).click()
+    await page.getByRole('link', { name: /^Pods$/ }).click()
     const element = page.locator(`.emphasize:has-text("podinfo")`).first()
     await expect(element).toBeVisible()
 

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -87,7 +87,7 @@ test.describe('Navigation', async () => {
   test.describe('navigates to Workloads', async () => {
     test('Pods page', async ({ page }) => {
       await page.getByRole('button', { name: 'Workloads' }).click()
-      await page.getByRole('link', { name: 'Pods' }).click()
+      await page.getByRole('link', { name: /^Pods$/ }).click()
 
       const element = page.locator(`.emphasize:has-text("podinfo")`).first()
       await expect(element).toBeVisible()

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -245,7 +245,7 @@ test.describe('Navigation', async () => {
   })
 
   test('navigates to Nodes page', async ({ page }) => {
-    await page.getByRole('link', { name: 'Nodes' }).click()
+    await page.getByRole('link', { name: /^Nodes$/ }).click()
 
     await expect(page.getByTestId('control-plane, master-testid-3')).toHaveText('control-plane, master')
   })

--- a/ui/tests/navigation.spec.ts
+++ b/ui/tests/navigation.spec.ts
@@ -48,6 +48,18 @@ test.describe('Navigation', async () => {
     await expect(overviewPodCount).toEqual(podCount)
   })
 
+  test('Navigate to page when click on Pod and Node Cards', async ({ page }) => {
+    const podsCard = page.getByTestId('card-container').filter({ hasText: 'Pods running in Cluster' })
+    await podsCard.click()
+    expect(await page.getByTestId('table-header').textContent()).toEqual('Pods')
+
+    await page.goto('/')
+
+    const nodesCard = page.getByTestId('card-container').filter({ hasText: 'Nodes running in Cluster' })
+    await nodesCard.click()
+    expect(await page.getByTestId('table-header').textContent()).toEqual('Nodes')
+  })
+
   test.describe('navigates to Applications', async () => {
     test('Packages page', async ({ page }) => {
       await page.getByRole('button', { name: 'Applications' }).click()


### PR DESCRIPTION
## Description
Currently on the overview page if we try to navigate to Pods or Nodes page by clicking on the overview cards at the top, they do not navigate unless you click on the content area. 

This change, adds the ability to navigate by clicking anywhere on the card

## Related Issue

- #484 


## Video Recording

https://github.com/user-attachments/assets/ddfe4888-1d13-463a-a744-1533bb800f00

